### PR TITLE
Expose API in addition to the command-line option

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -20,9 +20,26 @@
     under the License.
  */
 var Deploy = {
-    run: function(options, callback) {
+    _configureAWS: function(options) {
         var AWS = require('aws-sdk');
-        AWS.config.region = options.region || 'us-east-1';
+
+        if (options.accessKeyId) {
+            var awsConfig = {
+                accessKeyId: options.accessKeyId,
+                secretAccessKey: options.secretAccessKey,
+                region: options.region || 'us-east-1'
+            };
+            AWS.config.update(awsConfig);
+        }
+        else {
+            AWS.config.region = options.region || 'us-east-1';            
+        }
+
+        return AWS;
+    },
+
+    run: function(options, callback) {
+        var AWS = this._configureAWS(options);
         var opsWorks = new AWS.OpsWorks();
         var AppService = require('./lib/app_service')(opsWorks);
         var DeploymentService = require('./lib/deployment_service')(opsWorks);


### PR DESCRIPTION
Nice little utility here. 

This PR wraps `deploy.js` in a module and exposes it so that it can be called programmatically. `deploy.js` can still be run as a command-line utility. 

The API uses a standard callback with arguments `(error, result)`, but for now the error property is always null. Further work could switch and/or catch thrown exceptions and feed them into the error argument (instead of just throwing them).

The result to the callback is an object instead of a status so it can easily be extended in the future:

``` javascript
{
  status: '...'
}
```

Here's a quick sample of how the call works:

``` javascript
var deployer = require('opsworks-deploy');
deployer.run({
  accessKeyId: '...',
  secretAccessKey: '...',
  region: '...',
  stackId: '...',
  layerId: '...',
  appId: '...',
  rolling: true|false
}, (err, result) => {
  if (err) {
    ...
  }
  else {
    ...
  }
});
```

Cheers!
